### PR TITLE
Fixes CORS Allowed Origins issue for ASGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,17 @@ In the directory that contains `manage.py`, run the following command to start t
 daphne nEDM_server.asgi:application
 ```
 
+Basic queries can now be tested at the graphql endpoint, located at
+
+http://127.0.0.1:8000/graphql/
+
+**Note that the forward slash at the end is MANDATORY**
+
 ## Running the Apollo Client (FE)
 
 Install FE dependencies
+
+In the root directory, run
 
 ```
 npm install

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -36,12 +36,12 @@ root.render(
 reportWebVitals();
 
 // Test query to make sure connection with graphql endpoint works
-// client
-//   .query({
-//     query: gql`
-//       query{
-//         listHistograms
-//       }
-//     `
-//   })
-//   .then(result => console.log(result));
+client
+  .query({
+    query: gql`
+      query{
+        listHistograms
+      }
+    `
+  })
+  .then(result => console.log(result));

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -15,7 +15,6 @@ cryptography==36.0.2
 daphne==3.0.2
 dataclasses==0.8
 Django==3.2.12
-django-cors-headers==3.10.1
 graphql-core==3.1.7
 hyperlink==21.0.0
 idna==3.3

--- a/nEDM_server/nEDM_server/asgi.py
+++ b/nEDM_server/nEDM_server/asgi.py
@@ -21,11 +21,21 @@ from .graphql_config import schema
 from django.urls import path, re_path
 from django.conf import settings
 from channels.routing import URLRouter
+from channels.auth import AuthMiddlewareStack
+from starlette.middleware.cors import CORSMiddleware
 
-
-application = URLRouter(
-    [
-        path("graphql/", GraphQL(schema, debug=settings.DEBUG)),
-        re_path(r"", get_asgi_application())
-    ]
+application = AuthMiddlewareStack( 
+    URLRouter(
+        [
+            path(
+                "graphql/",
+                CORSMiddleware(
+                    GraphQL(schema, debug=settings.DEBUG),
+                    allow_origins=settings.CORS_ALLOWED_ORIGINS,
+                    allow_methods=["*"]
+            ),
+        ),
+            re_path(r"", get_asgi_application())
+        ]
+    )
 )

--- a/nEDM_server/nEDM_server/settings.py
+++ b/nEDM_server/nEDM_server/settings.py
@@ -23,8 +23,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
-ALLOWED_HOSTS = []
-
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+]
 
 # Application definition
 
@@ -37,12 +39,10 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'ariadne_django',
     'histograms',
-    'corsheaders',
     'channels',
 ]
 
 MIDDLEWARE = [
-    "corsheaders.middleware.CorsMiddleware",
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Fixes CORS allowed origins issues caused by moving to an asgi framework based on django channels. The original django cors middleware breaks. 

This pull request removes the django cors middleware and replaces it with the Starlette CORSMiddleware package

It is of note that you cannot use the Django channels origin validator middleware as that can only field a websocket request. In our situation we have both WS and http requests fielded at the same url.