### PR TITLE
histogram retrieval filter restriction

### DIFF
--- a/nEDM_server/histograms/query.py
+++ b/nEDM_server/histograms/query.py
@@ -20,6 +20,9 @@ def _get_histogram( id, database_name):
 @database_sync_to_async
 def _filter_histograms(ids, types, minDate, maxDate, 
                         minBins, maxBins, isLive):
+    if any(arg is None for arg in (ids, types, minDate, maxDate, minBins, maxBins, isLive))):
+        raise ValueError("At least one field filter must be specified")   
+                        
     queryset = Histogram.objects.using( chooseDatabase(isLive) ).all()
     if ids:
         queryset = queryset.filter(id__in=ids)

--- a/nEDM_server/histograms/query.py
+++ b/nEDM_server/histograms/query.py
@@ -20,9 +20,10 @@ def _get_histogram( id, database_name):
 @database_sync_to_async
 def _filter_histograms(ids, types, minDate, maxDate, 
                         minBins, maxBins, isLive):
-    if any(arg is None for arg in (ids, types, minDate, maxDate, minBins, maxBins, isLive))):
+    if (all([arg is None for arg in (ids, types, minDate, maxDate, minBins, maxBins)])
+         and (isLive == False)):
         raise ValueError("At least one field filter must be specified")   
-                        
+
     queryset = Histogram.objects.using( chooseDatabase(isLive) ).all()
     if ids:
         queryset = queryset.filter(id__in=ids)


### PR DESCRIPTION
Requires at least one filter to be specified when retrieving histograms through the _filter_histograms async generator to avoid a scenario where all histograms from the db are puled