### PR TITLE
Reimplements package.js fix that was accidentally reverted 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,6 @@ venv.bak/
 # Security settings on the server
 **/security.py
 
-#ignore VS Code files
-.vscode/
-compile_commands.json
-
 # Logs
 *.log
 

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,9 @@
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.6.3",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@apollo/client": "^3.5.10",
+    "graphql": "^16.3.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Turns out I am a big idiot for accidentally reverting fixes implemented in 9a099994b1ab83910b5594f1f05eda0c17ecafad

- Fixes missing graphql and apollo client dependencies in package.json
- Removes vscode-related lines from the gitignore