### PR TITLE
Add additional fields to live histogram subscription

### DIFF
--- a/client/src/components/EMS.graphql
+++ b/client/src/components/EMS.graphql
@@ -20,5 +20,6 @@ subscription getAllLiveHistograms {
     y
     xCurrent
     yCurrent
+    yMax
   }
 }

--- a/client/src/components/EMS.tsx
+++ b/client/src/components/EMS.tsx
@@ -39,6 +39,7 @@ const EMS = () => {
             <br />
             <dt>Y-Axis</dt>
             <dd>{liveHistogram?.yCurrent}</dd>
+            <dd>{liveHistogram?.yMax}</dd>
             <br />
           </dl>
         </>

--- a/server/histograms/schema.graphql
+++ b/server/histograms/schema.graphql
@@ -2,9 +2,31 @@ type Histogram {
   """
   - `id`: unique integer identifier of a histogram
   - `name`: String, can be duplicate
+  - `x`: Array of x points
+  - `y`: Array of y points
   - `len`: Number of data points
-  - `xCurrent`: The last added x data point. Only updated when `getLiveHistograms` subscription is called
-  - `yCurrent`: The last added y data point. Only updated when `getLiveHistograms` subscription is called
+  - `type`: Additional meta data
+  - `created`: Datetime when histogram was made in the database
+  """
+  id: ID
+  name: String
+  y: [Int]
+  x: [Int]
+  len: Int
+  type: String
+  created: Datetime
+}
+
+type LiveHistogram {
+  """
+  - `id`: unique integer identifier of a histogram
+  - `name`: String, can be duplicate
+  - `x`: Array of x points
+  - `y`: Array of y points
+  - `len`: Number of data points
+  - `xCurrent`: The last added x data point
+  - `yCurrent`: The last added y data point
+  - `yMax`: The largest y value in the in y
   - `type`: Additional meta data
   - `created`: Datetime when histogram was made in the database
   """
@@ -15,6 +37,7 @@ type Histogram {
   len: Int
   xCurrent: Int
   yCurrent: Int
+  yMax: Int
   type: String
   created: Datetime
 }

--- a/server/histograms/subscription.py
+++ b/server/histograms/subscription.py
@@ -2,7 +2,7 @@ from ariadne import SubscriptionType
 
 from .common import clean_hist_output
 import asyncio
-import datetime
+import numpy as np
 
 subscription = SubscriptionType()
 
@@ -25,6 +25,7 @@ async def source_live_histograms(obj, info):
                 if histograms[i].x and histograms[i].y:
                     histograms[i].xCurrent = histograms[i].x[-1]
                     histograms[i].yCurrent = histograms[i].y[-1]
+                    histograms[i].yMax = np.amax(histograms[i].y)
             yield histograms
         else:
             yield None

--- a/server/nEDM_server/schema.graphql
+++ b/server/nEDM_server/schema.graphql
@@ -144,7 +144,7 @@ type Subscription {
 
   Returns null every second when no data to publish
   """
-  getLiveHistograms: [Histogram]
+  getLiveHistograms: [LiveHistogram]
 
   """
   Retrieves the current run. The only live updating field is


### PR DESCRIPTION
## FE
- Add a yMax field underneath the yCurrent field on the EMS page
- Update the `EMS.graphql` file to account for the new yMax field

## BE
- Add yMax field to histogram subscriptions
- Create a new graphql output type, `LiveHistogram`, specifically for histogram subscriptions